### PR TITLE
複数のマップデータをシリアライズできるMapDataContenaクラスとStoreMapDataクラスを作成しました

### DIFF
--- a/Assets/Script/MapDataContena.cs
+++ b/Assets/Script/MapDataContena.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+
+[Serializable]
+public class MapDataContena
+{
+    [SerializeField] private string _mapDataName;
+    [SerializeField] private MapData _mapData;
+
+    public string MapDataName => _mapDataName;
+    public MapData MapData => _mapData;
+
+    public MapDataContena(string mapDataName, MapData mapData)
+    {
+        _mapDataName = mapDataName;
+        _mapData = mapData;
+    }
+
+    public void SetMapDataName(string name)
+    {
+        _mapDataName = name;
+    }
+}
+
+[Serializable]
+public class MapDataStore
+{
+    [SerializeField] private MapDataContena[] _contenas = new MapDataContena[5];
+    int _contenaCount = 0;
+
+    public void SetContena(MapDataContena contena)
+    {
+        if (_contenaCount > _contenas.Length - 1) return;
+        _contenas[_contenaCount] = contena;
+    }
+
+    public MapDataContena GetContna(int index)
+    {
+        if (_contenaCount > _contenas.Length - 1) return new MapDataContena("",new MapData(1,1,""));
+
+        return _contenas[index];
+    }
+
+    public MapDataContena[] GetContnas => _contenas;
+}

--- a/Assets/Script/MapDataContena.cs.meta
+++ b/Assets/Script/MapDataContena.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c09501c13fe48b40b7e26ba09292f33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/MazeMapping.cs
+++ b/Assets/Script/MazeMapping.cs
@@ -234,11 +234,16 @@ public class MazeMapping : MonoBehaviour
 public class MapData
 {
     /// <summary>マップサイズX</summary>
-    public int x;
+    [SerializeField]private int _x;
     /// <summary>マップサイズZ</summary>
-    public int z;
+    [SerializeField]private int _z;
     /// <summary>文字列マップデータ</summary>
-    public string stringMapData;
+    [SerializeField]private string _stringMapData;
+
+
+    public int x => _x;
+    public int z => _z;
+    public string stringMapData => _stringMapData;
 
     /// <summary>
     /// マップデータ初期化
@@ -248,8 +253,8 @@ public class MapData
     /// <param name="mapdata">文字列マップデータ</param>
     public MapData(int mapx, int mapz, string mapdata)
     {
-        x = mapx;
-        z = mapz;
-        stringMapData = mapdata;
+        _x = mapx;
+        _z = mapz;
+        _stringMapData = mapdata;
     }
 }


### PR DESCRIPTION
複数のマップデータの保存を可能にするためのMapDataContenaクラスとStoreMapDataクラスを作成しました

MapDataContenaクラス：マップデータに名前を付ける機能を
プロパティ
・MapDataName：マップデータに対しての名前となるstring型を返すプロパティ
・MapData：格納されているマップデータであるMapData型を返すプロパティ
コンストラクタ
・引数1 name：string型 引数2 mapdata:MapData型
   MapDataName変数をnameで、MapData変数をmapdataで初期化したMapDataContenaクラスのインスタンスを作成します。　
メソッド
・SetMapDataNameメソッド：引数1 name：string型
　コンテナのMapDataNameをnameで上書きするメソッド

StoreMapDataクラス：マップコンテナを複数保持するためのクラス
メソッド
・SetContenaメソッド：引数1 contena:MapDataContena型
　保持するコンテナの配列にcontenaを新たに加えますコンテナは5つまで保持できます
・GetContenaメソッド：引数1 index:int型　戻り値 MapDataContena型
  保持しているコンテナの配列からindex番目のMapDataContenaを返します
・GetContenasメソッド（プロパティ） 戻り値：MapDataContena[]型
　保持しているコンテナの配列を返します。形としてプロパティの形式をとっています
　
